### PR TITLE
fix: Update Sys Version [TAP-574]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ require (
 	github.com/coreos/go-semver v0.3.0
 	github.com/spf13/cobra v0.0.5
 	github.com/stretchr/testify v1.4.0
+	golang.org/x/sys v0.0.0-20220829200755-d48e67d00261 // indirect
 	gopkg.in/src-d/go-git.v4 v4.13.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/coreos/go-semver v0.3.0 h1:wkHLiw0WNATZnSG7epLsujiMCgPAc9xhjJ4tgnAxmf
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
@@ -75,6 +77,8 @@ golang.org/x/sys v0.0.0-20190221075227-b4e8571b14e0/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e h1:D5TXcfTk7xF7hvieo4QErS3qqCB4teTffacDWr7CI+0=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220829200755-d48e67d00261 h1:v6hYoSR9T5oet+pMXwUWkbiVqx/63mlHjefrHmxwfeY=
+golang.org/x/sys v0.0.0-20220829200755-d48e67d00261/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=


### PR DESCRIPTION
# Description

Attempting to install `release-version` was met with this error:
```
# golang.org/x/sys/unix
golang/pkg/mod/golang.org/x/sys@v0.0.0-20190726091711-fc99dfbffb4e/unix/zsyscall_darwin_arm64.go:28:3: //go:linkname must refer to declared function or variable
golang/pkg/mod/golang.org/x/sys@v0.0.0-20190726091711-fc99dfbffb4e/unix/zsyscall_darwin_arm64.go:43:3: //go:linkname must refer to declared function or variable
golang/pkg/mod/golang.org/x/sys@v0.0.0-20190726091711-fc99dfbffb4e/unix/zsyscall_darwin_arm64.go:59:3: //go:linkname must refer to declared function or variable
golang/pkg/mod/golang.org/x/sys@v0.0.0-20190726091711-fc99dfbffb4e/unix/zsyscall_darwin_arm64.go:75:3: //go:linkname must refer to declared function or variable
golang/pkg/mod/golang.org/x/sys@v0.0.0-20190726091711-fc99dfbffb4e/unix/zsyscall_darwin_arm64.go:90:3: //go:linkname must refer to declared function or variable
golang/pkg/mod/golang.org/x/sys@v0.0.0-20190726091711-fc99dfbffb4e/unix/zsyscall_darwin_arm64.go:105:3: //go:linkname must refer to declared function or variable
golang/pkg/mod/golang.org/x/sys@v0.0.0-20190726091711-fc99dfbffb4e/unix/zsyscall_darwin_arm64.go:121:3: //go:linkname must refer to declared function or variable
golang/pkg/mod/golang.org/x/sys@v0.0.0-20190726091711-fc99dfbffb4e/unix/zsyscall_darwin_arm64.go:136:3: //go:linkname must refer to declared function or variable
golang/pkg/mod/golang.org/x/sys@v0.0.0-20190726091711-fc99dfbffb4e/unix/zsyscall_darwin_arm64.go:151:3: //go:linkname must refer to declared function or variable
golang/pkg/mod/golang.org/x/sys@v0.0.0-20190726091711-fc99dfbffb4e/unix/zsyscall_darwin_arm64.go:166:3: //go:linkname must refer to declared function or variable
golang/pkg/mod/golang.org/x/sys@v0.0.0-20190726091711-fc99dfbffb4e/unix/zsyscall_darwin_arm64.go:166:3: too many errors
```

ran `go get -u golang.org/x/sys/unix` to update broken version with go 1.18.5+